### PR TITLE
Enable remotable functions from Internal.Types

### DIFF
--- a/src/Control/Distributed/Process/Platform.hs
+++ b/src/Control/Distributed/Process/Platform.hs
@@ -12,6 +12,7 @@ module Control.Distributed.Process.Platform
   (
     -- * Exported Types
     Addressable(..)
+  , Shutdown(..)
   , Recipient(..)
   , TerminateReason(..)
   , Tag
@@ -39,6 +40,7 @@ module Control.Distributed.Process.Platform
 import Control.Distributed.Process
 import Control.Distributed.Process.Platform.Internal.Types
   ( Recipient(..)
+  , Shutdown(..)
   , TerminateReason(..)
   , Tag
   , TagPool

--- a/src/Control/Distributed/Process/Platform/ManagedProcess.hs
+++ b/src/Control/Distributed/Process/Platform/ManagedProcess.hs
@@ -150,7 +150,7 @@
 --
 -- /Example: How to annoy your supervisor and end up force-killed:/
 --
--- > handleExit  (\state from (sigExit :: Shutdown) -> continue s)
+-- > handleExit  (\state from (sigExit :: Shutdown) -> continue state)
 --
 -- That code is, of course, very silly. Under some circumstances, handling
 -- exit signals is perfectly legitimate. Handling of /other/ forms of


### PR DESCRIPTION
I had to make this change in order to get resolving of `RemoteRegistered` `Recipients` to work. 
