### PR TITLE
Update dependency on distributed-process to >= 0.5.0

### DIFF
--- a/distributed-process-platform.cabal
+++ b/distributed-process-platform.cabal
@@ -32,7 +32,7 @@ library
   build-depends:
                    base >= 4,
                    data-accessor >= 0.2.2.3,
-                   distributed-process >= 0.4.2,
+                   distributed-process >= 0.5.0,
                    binary >= 0.6.3.0 && < 0.8,
                    deepseq >= 1.3.0.1 && < 1.4,
                    mtl,


### PR DESCRIPTION
The .cabal file requires 0.4.2 but master will not build with 0.4.2 due to imports of UnsafePrimitives
