### PR TITLE
add missing monitor on CreateHandle variant of ChildStart in Supervisor

### DIFF
--- a/src/Control/Distributed/Process/Platform/Supervisor.hs
+++ b/src/Control/Distributed/Process/Platform/Supervisor.hs
@@ -1588,6 +1588,7 @@ tryStartChild ChildSpec{..} =
       super <- getSelfPid
       (pid, msg) <- proc super
       maybeRegister regName pid
+      void $ monitor pid
       return $ ChildRunningExtra pid msg
 
     wrapRestarterProcess :: Maybe RegisteredName


### PR DESCRIPTION
Without this the child process is unsupervised.
