### PR TITLE
remove potential pattern match failure for more helpful `die msg`

### DIFF
--- a/src/Control/Distributed/Process/Platform/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Platform/Internal/Types.hs
@@ -27,6 +27,7 @@ module Control.Distributed.Process.Platform.Internal.Types
   , RegisterSelf(..)
     -- * Interactions
   , whereisRemote
+  , resolveOrDie
   , CancelWait(..)
   , Channel
   , Shutdown(..)
@@ -266,3 +267,11 @@ instance Routable (Message -> Process ()) where
 class (Resolvable a, Routable a) => Addressable a
 instance (Resolvable a, Routable a) => Addressable a
 
+-- TODO: this probably belongs somewhere other than in ..Types.
+-- | resolve the Resolvable or die with specified msg plus details of what didn't resolve
+resolveOrDie  :: (Routable a, Resolvable a) => a -> String -> Process ProcessId
+resolveOrDie resolvable failureMsg = do
+  result <- resolve resolvable
+  case result of
+    Nothing -> die $ failureMsg ++ " " ++ unresolvableMessage resolvable
+    Just pid -> return pid

--- a/src/Control/Distributed/Process/Platform/ManagedProcess/Internal/Types.hs
+++ b/src/Control/Distributed/Process/Platform/ManagedProcess/Internal/Types.hs
@@ -59,6 +59,7 @@ import Control.Distributed.Process.Platform.Internal.Types
   , Resolvable(..)
   , Routable(..)
   , NFSerializable
+  , resolveOrDie
   )
 import Control.Distributed.Process.Platform.Time
 import Control.DeepSeq (NFData)
@@ -373,38 +374,26 @@ data ProcessDefinition s = ProcessDefinition {
 -- TODO: Generify this /call/ API and use it in Call.hs to avoid tagging
 
 -- TODO: the code below should be moved elsewhere. Maybe to Client.hs?
-
-_resolveOrDie  :: (Routable a, Resolvable a)
-               => a -> String -> (ProcessId -> Process b) -> Process b
-_resolveOrDie addressable failureMsgPrefix action = do
-  result <- resolve addressable
-  case result of
-    Nothing -> die $ failureMsgPrefix ++ unresolvableMessage addressable
-    Just pid -> action pid
-
-initCall :: forall s a b . (Addressable s,
-                            Serializable a, Serializable b)
+initCall :: forall s a b . (Addressable s, Serializable a, Serializable b)
          => s -> a -> Process (CallRef b)
-initCall sid msg =
-  let failureMsgPrefix = "initCall: unresolveable address "
-  in _resolveOrDie sid failureMsgPrefix $ \pid -> do
-    mRef <- monitor pid
-    self <- getSelfPid
-    let cRef = makeRef (Pid self) mRef in do
-      sendTo pid (CallMessage msg cRef :: Message a b)
-      return cRef
+initCall sid msg = do
+  pid <- resolveOrDie sid "initCall: unresolveable address "
+  mRef <- monitor pid
+  self <- getSelfPid
+  let cRef = makeRef (Pid self) mRef in do
+    sendTo pid (CallMessage msg cRef :: Message a b)
+    return cRef
 
 unsafeInitCall :: forall s a b . (Addressable s,
                                   NFSerializable a, NFSerializable b)
          => s -> a -> Process (CallRef b)
-unsafeInitCall sid msg =
-  let failureMsgPrefix = "unsafeInitCall: unresolveable address "
-  in _resolveOrDie sid failureMsgPrefix $ \pid -> do
-      mRef <- monitor pid
-      self <- getSelfPid
-      let cRef = makeRef (Pid self) mRef in do
-        unsafeSendTo pid (CallMessage msg cRef  :: Message a b)
-        return cRef
+unsafeInitCall sid msg = do
+  pid <- resolveOrDie sid "unsafeInitCall: unresolveable address "
+  mRef <- monitor pid
+  self <- getSelfPid
+  let cRef = makeRef (Pid self) mRef in do
+    unsafeSendTo pid (CallMessage msg cRef  :: Message a b)
+    return cRef
 
 waitResponse :: forall b. (Serializable b)
              => Maybe TimeInterval


### PR DESCRIPTION
`initCall` and `unsafeInitCall` in `D.P.P.ManagedProcess.Internal.Types`
were both vulnerable to pattern match failure when passed an
unresolvable `Addressable`. It is more helpful to the developer /
debugger to die with `unresolvableMessage addressable`.
