### PR TITLE
Fix process leak on Supervisor with StarterProcess (DPP-84)

### DIFF
--- a/src/Control/Distributed/Process/Platform/Supervisor.hs
+++ b/src/Control/Distributed/Process/Platform/Supervisor.hs
@@ -1105,7 +1105,7 @@ handleDeleteChild st0 (DeleteChild k) = handleDelete k st0
                  -> State
                  -> Process (ProcessReply DeleteChildResult State)
     handleDelete key st =
-      let (prefix, suffix) = Seq.breakl ((== key) . childKey . snd) $ state ^. specs
+      let (prefix, suffix) = Seq.breakl ((== key) . childKey . snd) $ st ^. specs
       in case (Seq.viewl suffix) of
            EmptyL             -> reply ChildNotFound st
            child :< remaining -> tryDeleteChild child prefix remaining st


### PR DESCRIPTION
Fix https://cloud-haskell.atlassian.net/browse/DPP-84

When the StarterProcess ChildStart variant is used with dynamic
supervision, each cycle of startNewChild + terminateChild/deleteChild
leaks a process.

Note, this required converting `handleDeleteChild` from `RestrictedProcess` to `Process`.
