### PR TITLE
fix issue dpp-105; NominalDiffTime to TimeInterval conversion

### DIFF
--- a/src/Control/Distributed/Process/Platform/Time.hs
+++ b/src/Control/Distributed/Process/Platform/Time.hs
@@ -198,7 +198,7 @@ timeIntervalToDiffTime ti = microsecondsToNominalDiffTime (fromIntegral $ asTime
 
 -- | given a @NominalDiffTim@@, provide an equivalent @TimeInterval@
 diffTimeToTimeInterval :: NominalDiffTime -> TimeInterval
-diffTimeToTimeInterval dt = microSeconds $ (fromIntegral ((round dt)::Integer) `div` 1000000)
+diffTimeToTimeInterval dt = microSeconds $ (fromIntegral (round (dt * 1000000) :: Integer))
 
 -- | given a @Delay@, provide an equivalent @NominalDiffTim@
 delayToDiffTime :: Delay -> NominalDiffTime


### PR DESCRIPTION
NominalDiffTime converts in terms of seconds, so we need to multiply by 1,000,000 before rounding to convert to
microseconds.
