### PR TITLE
add logging to ChildInitFailure handler

### DIFF
--- a/src/Control/Distributed/Process/Platform/Supervisor.hs
+++ b/src/Control/Distributed/Process/Platform/Supervisor.hs
@@ -1633,7 +1633,13 @@ filterInitFailures :: ProcessId
                    -> Process ()
 filterInitFailures sup pid ex = do
   case ex of
-    ChildInitFailure _ -> liftIO $ throwIO ex
+    ChildInitFailure _ -> do
+      -- This is used as a `catches` handler in multiple places
+      -- and matches first before the other handlers that
+      -- would call logFailure.
+      -- We log here to avoid silent failure in those cases.
+      logEntry Log.error $ mkReport "ChildInitFailure" sup (show pid) (show ex)
+      liftIO $ throwIO ex
     ChildInitIgnore    -> Unsafe.cast sup $ IgnoreChildReq pid
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
ChildInitFailure's were being handled in a way that prevented
logFailure from being called appropriately. This affected
tryChildStart and the spawnIt helper used in the StarterProcess
variants of ToChildStart.
