### PR TITLE
fix symbol encoding (fixes HsColour)

### DIFF
--- a/src/Control/Distributed/Process/Platform/Time.hs
+++ b/src/Control/Distributed/Process/Platform/Time.hs
@@ -147,7 +147,7 @@ hours = TimeInterval Hours
 {-# INLINE timeToMicros #-}
 timeToMicros :: TimeUnit -> Int -> Int
 timeToMicros Micros  us   = us
-timeToMicros Millis  ms   = ms  * (10 ^ (3 :: Int)) -- (1000µs == 1ms)
+timeToMicros Millis  ms   = ms  * (10 ^ (3 :: Int)) -- (1000Âµs == 1ms)
 timeToMicros Seconds secs = timeToMicros Millis  (secs * milliSecondsPerSecond)
 timeToMicros Minutes mins = timeToMicros Seconds (mins * secondsPerMinute)
 timeToMicros Hours   hrs  = timeToMicros Minutes (hrs  * minutesPerHour)


### PR DESCRIPTION
For some reason, "µ" symbol was in "latin1" encoding in this file. This was breaking HsColour with obscure error. Fixing this would probably fix Hackage documentation, too.
