### PR TITLE
Don't use lliteral Haskell in Setup.hs file

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
-> import Distribution.Simple
-> main = defaultMain
+import Distribution.Simple
+main = defaultMain


### PR DESCRIPTION
This should fix building this package with Nix, and also is probably "the right thing to do". The other way would be to rename file to *.lhs.
