### PR TITLE
Implement waitCancelTimeout for STM version of async.

### DIFF
--- a/src/Control/Distributed/Process/Platform/Async/AsyncSTM.hs
+++ b/src/Control/Distributed/Process/Platform/Async/AsyncSTM.hs
@@ -55,6 +55,7 @@ module Control.Distributed.Process.Platform.Async.AsyncSTM
   , waitAnyTimeout
   , waitTimeout
   , waitCheckTimeout
+  , waitCancelTimeout
     -- * STM versions
   , pollSTM
   , waitTimeoutSTM
@@ -240,6 +241,19 @@ waitTimeout t hAsync = do
   (sp, rp) <- newChan :: (Serializable a) => Process (Channel (AsyncResult a))
   pid <- spawnLocal $ wait hAsync >>= sendChan sp
   receiveChanTimeout (asTimeout t) rp `finally` kill pid "timeout"
+
+-- | Wait for an asynchronous operation to complete or timeout. If it times out,
+-- then 'cancelWait' the async handle instead.
+--
+waitCancelTimeout :: (Serializable a)
+                  => TimeInterval
+                  -> AsyncSTM a
+                  -> Process (AsyncResult a)
+waitCancelTimeout t hAsync = do
+  r <- waitTimeout t hAsync
+  case r of
+    Nothing -> cancelWait hAsync
+    Just ar -> return ar
 
 -- | As 'waitTimeout' but uses STM directly, which might be more efficient.
 waitTimeoutSTM :: (Serializable a)

--- a/tests/TestAsyncSTM.hs
+++ b/tests/TestAsyncSTM.hs
@@ -183,6 +183,11 @@ testAsyncRecursive result = do
     myNode <- processNodeId <$> getSelfPid
     fib (myNode,6) >>= stash result
 
+testAsyncWaitCancelTimeout :: TestResult (AsyncResult ()) -> Process ()
+testAsyncWaitCancelTimeout result = do
+     p1 <- async $ task $ sleep $ seconds 20
+     waitCancelTimeout (seconds 1) p1 >>= stash result
+
 tests :: LocalNode  -> [Test]
 tests localNode = [
     testGroup "Handling async results with STM" [
@@ -236,6 +241,10 @@ tests localNode = [
             (delayedAssertion
              "expected Fibonacci 6 to be evaluated, and value of 8 returned"
              localNode 8 testAsyncRecursive)
+        , testCase "testAsyncWaitCancelTimeout"
+	    (delayedAssertion
+	     "expected waitCancelTimeout to return a value"
+	     localNode AsyncCancelled testAsyncWaitCancelTimeout)
       ]
   ]
 


### PR DESCRIPTION
A missing STM function with tests for this function. Having this function allowes to switch from Chan based to STM based workers everywhere.
